### PR TITLE
Support toggling black tile symmetry and publishing updates to puzzles

### DIFF
--- a/ui/src/features/app/Crosswyrd.tsx
+++ b/ui/src/features/app/Crosswyrd.tsx
@@ -19,6 +19,7 @@ import {
   setWelcomeDialogState,
   selectDefaultGridDialogOpen,
   selectWelcomeDialogState,
+  setPublishInfo,
 } from '../builder/builderSlice';
 import CrosswordBuilder from '../builder/CrosswordBuilder';
 import GridsDialog, { blankGrid } from './GridsDialog';
@@ -137,6 +138,9 @@ export default function CrossWyrd() {
           // Now that we've selected a grid, we no longer need the dialog to be
           // open by default
           dispatch(setDefaultGridDialogOpen(false));
+          // We're starting a new puzzle, so don't persist any previous publish
+          // info
+          dispatch(setPublishInfo({ title: '', author: '', id: null }));
         }}
       />
       <PublishDialog

--- a/ui/src/features/builder/CrosswordBuilder.tsx
+++ b/ui/src/features/builder/CrosswordBuilder.tsx
@@ -112,11 +112,10 @@ export default function CrosswordBuilder({ grid }: Props) {
     checkFutureEmpty,
   } = useWaveAndPuzzleHistory(wave, puzzle);
   const [hoveredTile, setHoveredTile] = useState<LocationType | null>(null);
-  const [
-    wordLocationsGrid,
-    setWordLocationsGrid,
-  ] = useState<WordLocationsGridType | null>(null);
+  const [wordLocationsGrid, setWordLocationsGrid] =
+    useState<WordLocationsGridType | null>(null);
   const [autoFillRunning, setAutoFillRunning] = useState(false);
+  const [symmetricBlackTiles, setSymmetricBlackTiles] = useState(true);
 
   const {
     onClick,
@@ -126,16 +125,19 @@ export default function CrosswordBuilder({ grid }: Props) {
     selectBestNext,
     selectNextAnswer,
   } = useTileSelection(puzzle, wave, WFCBusy, autoFillRunning);
-  const clearHoveredTile = useCallback(() => setHoveredTile(null), [
-    setHoveredTile,
-  ]);
+  const clearHoveredTile = useCallback(
+    () => setHoveredTile(null),
+    [setHoveredTile]
+  );
   useTileInput(
     puzzle,
     selectedTilesState,
     updateSelection,
     clearHoveredTile,
     selectNextAnswer,
-    selectBestNext
+    selectBestNext,
+    false,
+    { symmetricBlackTiles }
   );
 
   const dispatch = useDispatch();
@@ -294,7 +296,7 @@ export default function CrosswordBuilder({ grid }: Props) {
       // slots with " "s.
       const word = _.join(
         _.times(tileLocations.length, (index) =>
-          rawWord[index] === '?' ? ' ' : rawWord[index] ?? ' '
+          rawWord[index] === '?' ? ' ' : (rawWord[index] ?? ' ')
         ),
         ''
       );
@@ -398,6 +400,8 @@ export default function CrosswordBuilder({ grid }: Props) {
             clearLetters={clearLetters}
             clearSelection={clearSelection}
             selectBestNext={selectBestNext}
+            setSymmetricBlackTiles={setSymmetricBlackTiles}
+            symmetricBlackTiles={symmetricBlackTiles}
           />
           <Tiles
             puzzle={puzzle}

--- a/ui/src/features/builder/PuzzleBanner.tsx
+++ b/ui/src/features/builder/PuzzleBanner.tsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import CloseIcon from '@mui/icons-material/Close';
 import UndoIcon from '@mui/icons-material/Undo';
 import RedoIcon from '@mui/icons-material/Redo';
+import BalanceIcon from '@mui/icons-material/Balance';
 import DoneIcon from '@mui/icons-material/Done';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import StopIcon from '@mui/icons-material/Stop';
@@ -14,10 +15,11 @@ import {
   Divider,
   IconButton,
   Popover,
+  ToggleButton,
   Tooltip,
   Typography,
 } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -26,6 +28,7 @@ import {
   setFillAssistActive,
 } from './builderSlice';
 import { AUTO_FILL_ASSIST_SUGGESTION_TOGGLE_THRESHOLD } from './constants';
+import { Clear, NavigateNext } from '@mui/icons-material';
 
 function FillAssistPopover({ anchorEl }: { anchorEl: HTMLElement }) {
   const [open, setOpen] = useState(false);
@@ -195,6 +198,8 @@ interface Props {
   clearLetters: () => void;
   clearSelection: () => void;
   selectBestNext: () => void;
+  setSymmetricBlackTiles: (value: boolean) => void;
+  symmetricBlackTiles: boolean;
 }
 
 export default function PuzzleBanner({
@@ -210,11 +215,11 @@ export default function PuzzleBanner({
   clearLetters,
   clearSelection,
   selectBestNext,
+  setSymmetricBlackTiles,
+  symmetricBlackTiles,
 }: Props) {
-  const [
-    fillAssistElement,
-    setFillAssistElement,
-  ] = useState<HTMLElement | null>(null);
+  const [fillAssistElement, setFillAssistElement] =
+    useState<HTMLElement | null>(null);
 
   const dispatch = useDispatch();
 
@@ -264,9 +269,13 @@ export default function PuzzleBanner({
         enterDelay={500}
       >
         <div style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-          <Button disabled={WFCBusy || autoFillRunning} onClick={clearLetters}>
-            Clear
-          </Button>
+          <IconButton
+            disabled={WFCBusy || autoFillRunning}
+            onClick={clearLetters}
+            color="primary"
+          >
+            <Clear />
+          </IconButton>
         </div>
       </Tooltip>
       <Tooltip
@@ -277,13 +286,38 @@ export default function PuzzleBanner({
         enterDelay={500}
       >
         <div style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-          <Button
+          <IconButton
             disabled={WFCBusy || autoFillRunning}
             onClick={selectBestNext}
+            color="primary"
           >
-            Next
-          </Button>
+            <NavigateNext />
+          </IconButton>
         </div>
+      </Tooltip>
+      <Tooltip
+        title={
+          symmetricBlackTiles
+            ? 'Turn off black tile symmetry'
+            : 'Turn on black tile symmetry'
+        }
+        placement="top"
+        arrow
+        disableInteractive
+        enterDelay={500}
+      >
+        <span>
+          <ToggleButton
+            size="small"
+            color="primary"
+            value="check"
+            onClick={() => setSymmetricBlackTiles(!symmetricBlackTiles)}
+            selected={symmetricBlackTiles}
+            component="span"
+          >
+            <BalanceIcon />
+          </ToggleButton>
+        </span>
       </Tooltip>
       <Divider
         orientation="vertical"
@@ -340,8 +374,8 @@ export default function PuzzleBanner({
               WFCBusy || autoFillRunning
                 ? 'running'
                 : autoFillErrored
-                ? 'error'
-                : 'success'
+                  ? 'error'
+                  : 'success'
             }
           />
           <Tooltip

--- a/ui/src/features/builder/builderSlice.ts
+++ b/ui/src/features/builder/builderSlice.ts
@@ -27,6 +27,11 @@ interface WelcomeDialogStateType {
   open: boolean;
   showCheckbox: boolean;
 }
+interface PublishInfoType {
+  title: string;
+  author: string;
+  id: string | null;
+}
 interface BuilderState {
   puzzle: CrosswordPuzzleType;
   wave: WaveType | null;
@@ -39,6 +44,7 @@ interface BuilderState {
   defaultGridDialogOpen: boolean;
   welcomeDialogState: WelcomeDialogStateType;
   tileUpdates: TileUpdateType[];
+  publishInfo: PublishInfoType;
 }
 
 export const DEFAULT_PUZZLE_SIZE = 15;
@@ -65,6 +71,7 @@ const initialState: BuilderState = {
   defaultGridDialogOpen: !devMode(),
   welcomeDialogState: { open: true, showCheckbox: true },
   tileUpdates: [],
+  publishInfo: { title: '', author: '', id: null },
 };
 
 export function getSymmetricTile(
@@ -126,6 +133,42 @@ export const builderSlice = createSlice({
       // tracked tile updates as well
       state.tileUpdates = [];
     },
+    mergePuzzleState: (
+      state,
+      action: PayloadAction<{
+        remotePuzzle: CrosswordPuzzleType;
+        puzzleId: string;
+      }>
+    ) => {
+      // Merge the preloaded puzzle atop the remote puzzle
+      state.puzzle = {
+        ...action.payload.remotePuzzle,
+        tiles: _.map(action.payload.remotePuzzle.tiles, (row, rowIndex) =>
+          _.map(row, (tile, columnIndex) => {
+            const preloadedTileValue: TileValueType | undefined =
+              action.payload.puzzleId === state.puzzle.uuid
+                ? state.puzzle.tiles[rowIndex]?.[columnIndex]?.value
+                : undefined;
+            return {
+              ...tile,
+              value:
+                tile.value === 'black'
+                  ? // Black remote tiles should always be preserved
+                    'black'
+                  : preloadedTileValue === 'black'
+                    ? // Black preloaded tiles should be treated as empty if the remote tile is empty
+                      'empty'
+                    : // Try to use the preloaded value if it's available--otherwise, empty
+                      (preloadedTileValue ?? 'empty'),
+            };
+          })
+        ),
+        uuid: action.payload.puzzleId,
+      };
+      // This function effectively destroys the puzzle, so we should reset our
+      // tracked tile updates as well
+      state.tileUpdates = [];
+    },
     setWaveState: (state, action: PayloadAction<WaveType | null>) => {
       state.wave = action.payload;
     },
@@ -177,6 +220,9 @@ export const builderSlice = createSlice({
     ) => {
       state.welcomeDialogState = action.payload;
     },
+    setPublishInfo: (state, action: PayloadAction<PublishInfoType>) => {
+      state.publishInfo = action.payload;
+    },
   },
 });
 
@@ -185,6 +231,7 @@ export const {
   bumpPuzzleVersion,
   toggleTileBlack,
   setPuzzleState,
+  mergePuzzleState,
   setDraggedWord,
   setCurrentTab,
   setFillAssistActive,
@@ -197,6 +244,7 @@ export const {
   setWaveState,
   setDefaultGridDialogOpen,
   setWelcomeDialogState,
+  setPublishInfo,
 } = builderSlice.actions;
 
 export const selectPuzzle = (state: RootState) => state.builder.puzzle;
@@ -216,5 +264,7 @@ export const selectWelcomeDialogState = (state: RootState) =>
   state.builder.welcomeDialogState;
 export const selectTileUpdates = (state: RootState) =>
   state.builder.tileUpdates;
+export const selectPublishInfo = (state: RootState) =>
+  state.builder.publishInfo;
 
 export default builderSlice.reducer;

--- a/ui/src/features/builder/builderSlice.ts
+++ b/ui/src/features/builder/builderSlice.ts
@@ -7,7 +7,7 @@ import { DirectionType } from './useTileSelection';
 import { TileUpdateType, WaveType } from './useWaveFunctionCollapse';
 import { devMode, randomId } from '../../app/util';
 
-export type LetterType = typeof ALL_LETTERS[number];
+export type LetterType = (typeof ALL_LETTERS)[number];
 
 export type TileValueType = LetterType | 'empty' | 'black';
 export interface TileType {
@@ -91,15 +91,18 @@ export const builderSlice = createSlice({
       action: PayloadAction<{
         row: number;
         column: number;
+        symmetricBlackTiles: boolean;
       }>
     ) => {
       const { row, column } = action.payload;
       const tile = state.puzzle.tiles[row][column];
       const newValue = tile.value === 'black' ? 'empty' : 'black';
-      const symmetricTile = getSymmetricTile(state.puzzle, row, column).tile;
 
       tile.value = newValue;
-      symmetricTile.value = newValue;
+      if (action.payload.symmetricBlackTiles) {
+        const symmetricTile = getSymmetricTile(state.puzzle, row, column).tile;
+        symmetricTile.value = newValue;
+      }
       state.puzzle.version = randomId();
     },
     setPuzzleTileValues: (state, action: PayloadAction<TileUpdateType[]>) => {

--- a/ui/src/features/builder/useTileInput.ts
+++ b/ui/src/features/builder/useTileInput.ts
@@ -43,7 +43,7 @@ const SUPPORTED_KEYS = [
   DOWN,
   SPACEBAR,
 ] as const;
-export type SupportedKeysType = typeof SUPPORTED_KEYS[number];
+export type SupportedKeysType = (typeof SUPPORTED_KEYS)[number];
 
 const INSURANCE_STRING = 'asecretsequencetoensuremycodehasntbeenplagiarized';
 function useInsurance(
@@ -98,7 +98,8 @@ export default function useTileInput(
   clearHoveredTile: () => void,
   selectNextAnswer: (forward: boolean, endOfAnswer?: boolean) => void,
   selectBestNext: () => void,
-  playerMode: boolean = false
+  playerMode: boolean = false,
+  options?: { symmetricBlackTiles?: boolean }
 ): ReturnType {
   const dispatch = useDispatch();
   // A map of key states, used to prevent rapid-fire keypresses by olding keys
@@ -255,7 +256,8 @@ export default function useTileInput(
             value: 'empty',
           };
           const symmetricTileInfo =
-            tileAtLocation(tileUpdate).value === 'black'
+            tileAtLocation(tileUpdate).value === 'black' &&
+            options?.symmetricBlackTiles
               ? getSymmetricTile(puzzle, tileUpdate.row, tileUpdate.column)
               : null;
 
@@ -395,6 +397,7 @@ export default function useTileInput(
     selectNextAnswer,
     selectBestNext,
     playerMode,
+    options?.symmetricBlackTiles,
   ]);
 
   // Add and remove event listeners

--- a/ui/src/features/builder/useTileInput.ts
+++ b/ui/src/features/builder/useTileInput.ts
@@ -314,7 +314,8 @@ export default function useTileInput(
                 : (key as LetterType),
           };
           const symmetricTileInfo =
-            tileUpdate.value === 'black' || currentTile.value === 'black'
+            options?.symmetricBlackTiles &&
+            (tileUpdate.value === 'black' || currentTile.value === 'black')
               ? getSymmetricTile(
                   puzzle,
                   newPrimaryLocation.row,


### PR DESCRIPTION
Per recent user requests, this PR adds support for toggling black tile symmetry and publishing updates to previously-published puzzles! The changes are fairly simple. Potential future improvements:
* Pick the kind of black tile symmetry (currently 180-degree rotational or none)
* Add auth support to associate puzzles with users, unlocking editing past puzzles (not just most recent), viewing past puzzles, etc.