### PR TITLE
update to remove 'FILL' suggestions when 'Fill Assist' is disabled

### DIFF
--- a/ui/src/features/builder/CrosswordBuilder.css
+++ b/ui/src/features/builder/CrosswordBuilder.css
@@ -190,6 +190,12 @@ body,
   margin-top: 10px;
 }
 
+.selector-fallback-notice {
+  text-align: center;
+  font-style: italic;
+  padding: 8px 12px 4px;
+}
+
 .selector-add-word-text {
   position: relative;
   left: -5px;

--- a/ui/src/features/builder/WordSelector.tsx
+++ b/ui/src/features/builder/WordSelector.tsx
@@ -102,36 +102,68 @@ function WordSelector({
       ),
     [selectedTilesState, puzzle]
   );
+  // The pattern of the selected word as typed so far (a letter where a tile
+  // is filled, '.' wherever it's empty or black), independent of anything
+  // the wave function collapse solver has narrowed down.
+  const tilesPattern: (LetterType | '.')[][] = useMemo(
+    () =>
+      _.map(_.range(optionsSet.length), (index) => {
+        const tileValue = selectedTiles[index].value;
+        if (tileValue === 'empty' || tileValue === 'black') return ['.'];
+        return [tileValue];
+      }),
+    [optionsSet.length, selectedTiles]
+  );
+
   const allPossibleWords = useMemo(
     () => findWordOptionsFromDictionary(dictionary, optionsSet),
     [dictionary, optionsSet]
   );
   const wordsFilteredByTiles = useMemo(
-    () =>
-      // Filter even before wave updates come in
-      findWordOptions(
-        allPossibleWords,
-        _.map(_.range(optionsSet.length), (index) => {
-          const tileValue = selectedTiles[index].value;
-          if (tileValue === 'empty' || tileValue === 'black') return ['.'];
-          return [tileValue];
-        })
-      ),
-    [allPossibleWords, optionsSet, selectedTiles]
+    // Filter even before wave updates come in
+    () => findWordOptions(allPossibleWords, tilesPattern),
+    [allPossibleWords, tilesPattern]
   );
+
+  // If the wave function collapse solver has narrowed the board down to no
+  // viable words here (e.g. because it can't find a way to fully solve the
+  // rest of the puzzle from this state), fall back to words that simply
+  // match the letters already typed in, unverified against the rest of the
+  // board.
+  const basicWordsFilteredByTiles = useMemo(
+    () =>
+      optionsSet.length === 0
+        ? []
+        : findWordOptionsFromDictionary(dictionary, tilesPattern),
+    [dictionary, tilesPattern, optionsSet.length]
+  );
+  const usingBasicFallback =
+    optionsSet.length > 0 &&
+    wordsFilteredByTiles.length === 0 &&
+    basicWordsFilteredByTiles.length > 0;
+
   const possibleWords = useMemo(() => {
+    const selectedWord = _.join(
+      _.times(optionsSet.length, (index) => selectedTiles[index].value),
+      ''
+    );
     const sortedWordsExceptSelectedWord = sortByWordScore(
       _.without(
-        wordsFilteredByTiles,
-        _.join(
-          _.times(optionsSet.length, (index) => selectedTiles[index].value),
-          ''
-        )
+        usingBasicFallback ? basicWordsFilteredByTiles : wordsFilteredByTiles,
+        selectedWord
       )
     );
     return sortedWordsExceptSelectedWord;
-  }, [wordsFilteredByTiles, selectedTiles, optionsSet]);
+  }, [
+    wordsFilteredByTiles,
+    basicWordsFilteredByTiles,
+    usingBasicFallback,
+    selectedTiles,
+    optionsSet,
+  ]);
 
+  // Viability checks rely on being able to solve the rest of the board, so
+  // they aren't meaningful for the basic fallback list--skip them there.
   const wordViabilities = useWordViabilities(
     dictionary,
     wave,
@@ -139,12 +171,20 @@ function WordSelector({
     possibleWords,
     selectedTilesState,
     autoFillRunning,
-    fillAssistActive
+    fillAssistActive && !usingBasicFallback
   );
 
   const mkHandleClickWord = (index: number) => () => {
     onEnter(possibleWords[index]);
   };
+
+  if (!fillAssistActive) {
+    return (
+      <div className="word-selector-container">
+        <span className="selector-comment">Fill Assist Disabled</span>
+      </div>
+    );
+  }
 
   return (
     <div className="word-selector-container">
@@ -158,6 +198,12 @@ function WordSelector({
             No words found to place here.
           </span>
         )
+      )}
+      {usingBasicFallback && (
+        <span className="selector-fallback-notice">
+          Unable to fill entire board - suggestions for the selected spaces
+          only
+        </span>
       )}
       <Box sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
         <List style={{ padding: 0 }}>

--- a/ui/src/features/builder/WordSelector.tsx
+++ b/ui/src/features/builder/WordSelector.tsx
@@ -115,52 +115,51 @@ function WordSelector({
     [optionsSet.length, selectedTiles]
   );
 
+  const selectedWord = useMemo(
+    () =>
+      _.join(
+        _.times(optionsSet.length, (index) => selectedTiles[index].value),
+        ''
+      ),
+    [selectedTiles, optionsSet.length]
+  );
+
   const allPossibleWords = useMemo(
     () => findWordOptionsFromDictionary(dictionary, optionsSet),
     [dictionary, optionsSet]
   );
   const wordsFilteredByTiles = useMemo(
     // Filter even before wave updates come in
-    () => findWordOptions(allPossibleWords, tilesPattern),
-    [allPossibleWords, tilesPattern]
+    () => _.without(findWordOptions(allPossibleWords, tilesPattern), selectedWord),
+    [allPossibleWords, tilesPattern, selectedWord]
   );
 
   // If the wave function collapse solver has narrowed the board down to no
-  // viable words here (e.g. because it can't find a way to fully solve the
-  // rest of the puzzle from this state), fall back to words that simply
+  // other viable words here (e.g. because it can't find a way to fully solve
+  // the rest of the puzzle from this state), fall back to words that simply
   // match the letters already typed in, unverified against the rest of the
-  // board.
+  // board. Only bother scanning the dictionary for this when we'd actually
+  // use the result.
   const basicWordsFilteredByTiles = useMemo(
     () =>
-      optionsSet.length === 0
+      optionsSet.length === 0 || wordsFilteredByTiles.length > 0
         ? []
-        : findWordOptionsFromDictionary(dictionary, tilesPattern),
-    [dictionary, tilesPattern, optionsSet.length]
+        : _.without(
+            findWordOptionsFromDictionary(dictionary, tilesPattern),
+            selectedWord
+          ),
+    [dictionary, tilesPattern, optionsSet.length, wordsFilteredByTiles, selectedWord]
   );
   const usingBasicFallback =
-    optionsSet.length > 0 &&
-    wordsFilteredByTiles.length === 0 &&
-    basicWordsFilteredByTiles.length > 0;
+    wordsFilteredByTiles.length === 0 && basicWordsFilteredByTiles.length > 0;
 
-  const possibleWords = useMemo(() => {
-    const selectedWord = _.join(
-      _.times(optionsSet.length, (index) => selectedTiles[index].value),
-      ''
-    );
-    const sortedWordsExceptSelectedWord = sortByWordScore(
-      _.without(
-        usingBasicFallback ? basicWordsFilteredByTiles : wordsFilteredByTiles,
-        selectedWord
-      )
-    );
-    return sortedWordsExceptSelectedWord;
-  }, [
-    wordsFilteredByTiles,
-    basicWordsFilteredByTiles,
-    usingBasicFallback,
-    selectedTiles,
-    optionsSet,
-  ]);
+  const possibleWords = useMemo(
+    () =>
+      sortByWordScore(
+        usingBasicFallback ? basicWordsFilteredByTiles : wordsFilteredByTiles
+      ),
+    [wordsFilteredByTiles, basicWordsFilteredByTiles, usingBasicFallback]
+  );
 
   // Viability checks rely on being able to solve the rest of the board, so
   // they aren't meaningful for the basic fallback list--skip them there.


### PR DESCRIPTION
## Summary
I don't always want to be shown an answer, so turning off "Fill Assist" now hides the FILL suggestion panel entirely, showing "Fill Assist Disabled" instead.

But sometimes I do want answers, even when the full solve is impossible — so when Fill Assist is on but the solver can't fully solve the rest of the board, FILL now falls back to plain letter-pattern matches (unverified) instead of showing nothing, with a small notice explaining why.

## Test plan
- [ ] Toggle Fill Assist off → FILL panel shows "Fill Assist Disabled", no suggestions.
- [ ] Toggle Fill Assist on, select a word the solver can't fully resolve → see fallback matches + notice, no overlap with the list.
- [ ] `yarn tsc --noEmit` passes.




## Disclosure:
I don't know typescript; I'm more of a vhdl and C kind of guy.  So this is vibe coded with Claude.